### PR TITLE
Make more elements optional, support other field definition types

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,12 @@ def import_svd(bv: BinaryView):
         per_base_addr: int = peripheral['baseAddress']
         per_struct = StructureBuilder.create()
 
-        per_registers = peripheral['registers']['register']
+        # the registers block is an optional 0..1 field in the SVD spec. Even
+        # if we don't get individual register definitions, we can create a
+        # memory region for a peripheral
+        per_registers = []
+        if 'registers' in peripheral:
+            per_registers = peripheral['registers']['register']
         for register in per_registers:
             reg_name: str = register['name']
             reg_desc: str = register['description']

--- a/__init__.py
+++ b/__init__.py
@@ -41,8 +41,22 @@ def import_svd(bv: BinaryView):
             reg_fields = register['fields']['field']
             for field in reg_fields:
                 field_name: str = field['name']
-                field_lsb: int = field['lsb']
-                field_msb: int = field['msb']
+                # one of the three following field bit specifications must be
+                # provided
+                if 'lsb' in field and 'msb' in field:
+                    field_lsb: int = field['lsb']
+                    field_msb: int = field['msb']
+                elif 'bitOffset' in field:
+                    field_lsb: int = field['bitOffset']
+                    # The bitWidth field is optional
+                    if 'bitWidth' in field:
+                        field_msb: int = field['bitOffset'] + field['bitWidth'] - 1
+                    else:
+                        field_msb: int = field['bitOffset']
+                elif 'bitRange' in field:
+                    msb_str, lsb_str = field['bitRange'].split(':', 1)
+                    field_lsb: int = int(lsb_str[:-1])
+                    field_msb: int = int(msb_str[1:])
                 field_lsb_b: float = field_lsb / BYTE_SIZE
                 field_msb_b: float = field_msb / BYTE_SIZE
 

--- a/__init__.py
+++ b/__init__.py
@@ -24,7 +24,9 @@ def import_svd(bv: BinaryView):
 
     for peripheral in peripherals:
         per_name: str = peripheral['name']
-        per_desc: str = peripheral['description']
+        per_desc = None
+        if 'description' in peripheral:
+            per_desc: str = peripheral['description']
         per_base_addr: int = peripheral['baseAddress']
         per_struct = StructureBuilder.create()
 
@@ -121,7 +123,7 @@ def import_svd(bv: BinaryView):
         bv.memory_map.add_memory_region(per_name, per_base_addr, bytearray(per_size))
 
         # Add the peripheral description as a comment
-        if show_comments:
+        if show_comments and per_desc is not None:
             bv.set_comment_at(per_base_addr, per_desc)
         # Define the peripheral type and data var in the binary view.
         per_struct_ty = Type.structure_type(per_struct)


### PR DESCRIPTION
The SVD spec says a number of fields that are currently accessed by the plugin are optional, and this causes issues with real SVDs in the wild. This PR handles some of them that I'm hitting.

This PR also adds support for the `bitRangeOffsetWidthStyle ` and `bitRangePattern` field definition types:
https://arm-software.github.io/CMSIS_5/SVD/html/elem_registers.html#:~:text=0..1-,Choice%20of,0..1,-access

You can find some example SVDs exhibiting these issues here:
https://github.com/ch32-rs/ch32-rs/blob/main/svd/fixed/ch59x.svd
https://github.com/ch32-rs/ch32-rs/blob/main/svd/fixed/ch32v30x.svd