### PR TITLE
Handle `<size>` set at `<device>` level

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -52,7 +52,7 @@ def import_svd(bv: BinaryView):
         # memory region for a peripheral
         for register in per_registers:
             reg_name: str = register['name']
-            reg_desc: str = register.get('description')
+            reg_desc: str | None = register.get('description')
             reg_addr_offset: int = register['addressOffset']
             reg_size: int = register['size']
             reg_size_b = int(reg_size / BYTE_SIZE)

--- a/__init__.py
+++ b/__init__.py
@@ -50,7 +50,13 @@ def import_svd(bv: BinaryView):
         # the registers block is an optional 0..1 field in the SVD spec. Even
         # if we don't get individual register definitions, we can create a
         # memory region for a peripheral
-        for register in per_registers:
+        for reg_index, register in enumerate(per_registers):
+            reg_missing: set[str] = {'name', 'addressOffset', 'size'} - set(register)
+            if reg_missing:
+                binaryninja.log_warn(
+                    f"peripheral {per_name} @ {per_base_addr:#x} register #{reg_index} ({register['name'] or '<no name>'}) is missing required tags: {', '.join(reg_missing)}")
+                continue
+
             reg_name: str = register['name']
             reg_desc: str | None = register.get('description')
             reg_addr_offset: int = register['addressOffset']

--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,7 @@ def import_svd(bv: BinaryView):
             per_derived_from = next(p for p in peripherals if p['name'] == per_derived_from_name)
             if per_derived_from is None:
                 binaryninja.log_error(
-                    f"peripheral {per_name} @ {per_base_addr} derives from unknown peripheral {per_derived_from_name}")
+                    f"peripheral {per_name} @ {per_base_addr:#x} derives from unknown peripheral {per_derived_from_name}")
                 continue
             peripheral['addressBlock'] = per_derived_from['addressBlock']
             per_registers.extend(per_derived_from['registers']['register'])
@@ -132,7 +132,7 @@ def import_svd(bv: BinaryView):
 
         if per_size < per_struct.width:
             binaryninja.log_warn(
-                f"peripheral {per_name} @ {per_base_addr} size is less than struct size... adjusting size to fit struct")
+                f"peripheral {per_name} @ {per_base_addr:#x} size is less than struct size... adjusting size to fit struct")
             per_size = per_struct.width
 
         # Add entire peripheral range

--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ def import_svd(bv: BinaryView):
     device_name: str = device['name']
     binaryninja.log_info(f'parsing device... {device_name}')
     peripherals = device['peripherals']['peripheral']
+    dev_size = device['size']
 
     show_comments = Settings().get_bool("SVDMapper.enableComments")
     structure_bitfields = Settings().get_bool("SVDMapper.enableBitfieldStructuring")
@@ -51,7 +52,10 @@ def import_svd(bv: BinaryView):
         # if we don't get individual register definitions, we can create a
         # memory region for a peripheral
         for reg_index, register in enumerate(per_registers):
-            reg_missing: set[str] = {'name', 'addressOffset', 'size'} - set(register)
+            reg_missing: set[str] = {'name', 'addressOffset', 'size'}
+            reg_missing -= set(register)
+            if dev_size is not None:
+                reg_missing -= {'size'}
             if reg_missing:
                 binaryninja.log_warn(
                     f"peripheral {per_name} @ {per_base_addr:#x} register #{reg_index} ({register['name'] or '<no name>'}) is missing required tags: {', '.join(reg_missing)}")
@@ -60,7 +64,7 @@ def import_svd(bv: BinaryView):
             reg_name: str = register['name']
             reg_desc: str | None = register.get('description')
             reg_addr_offset: int = register['addressOffset']
-            reg_size: int = register['size']
+            reg_size: int = register.get('size', dev_size)
             reg_size_b = int(reg_size / BYTE_SIZE)
             reg_addr = per_base_addr + reg_addr_offset
             reg_struct = StructureBuilder.create(width=reg_size_b)


### PR DESCRIPTION
The SVD file that would crash the plugin is here: [LPC11Uxx_v7.svd.zip](https://github.com/user-attachments/files/18220408/LPC11Uxx_v7.svd.zip)

With this PR it at least creates register definitions, but some of them have a `%s` in them. I might fix that later.